### PR TITLE
Allow a smart contract to be launched in the debugger from the invocation UI

### DIFF
--- a/src/invocationPanel.ts
+++ b/src/invocationPanel.ts
@@ -141,6 +141,11 @@ export class InvocationPanel {
             this.viewState.broadcastResult = '';
             this.viewState.showResult = false;
             this.panel.webview.postMessage({ viewState: this.viewState });
+        } else if (message.e === invokeEvents.Debug) {
+            if (!(await this.startDebugging())) {
+                this.viewState.invocationError = 'There was an error launching the debugger.';
+                this.panel.webview.postMessage({ viewState: this.viewState });
+            }
         }
     }
 
@@ -219,6 +224,10 @@ export class InvocationPanel {
             this.viewState.broadcastResult = undefined;
             this.viewState.invocationError = 'Could not invoke ' + methodName + ': ' + e;
         }
+    }
+
+    private async startDebugging() {
+        return false;
     }
 
     private static extractArguments(parameters: any[]) {

--- a/src/invocationPanel.ts
+++ b/src/invocationPanel.ts
@@ -289,7 +289,6 @@ export class InvocationPanel {
                                         }
                                     }
                                 };
-                                console.log(debugConfiguration);
                                 return await vscode.debug.startDebugging(undefined, debugConfiguration);
                             } else {
                                 this.viewState.invocationError = 'Could not find an AVM file for this contract in the current workspace.';

--- a/src/panels/invoke.html
+++ b/src/panels/invoke.html
@@ -112,6 +112,9 @@
                         <div>
                             <button class="invokeOffChainButton">Call method</button>
                         </div>
+                        <div>
+                            <button class="launchDebugger">Launch debugger</button>
+                        </div>
                     </div>
                     <div class="half right">
                         <table>

--- a/src/panels/invokeEvents.ts
+++ b/src/panels/invokeEvents.ts
@@ -6,6 +6,7 @@ const invokeEvents = {
     InvokeOffChain: 'invokeOffChain',
     Update: 'update',
     Dismiss: 'dismiss',
+    Debug: 'debug',
 };
 
 export { invokeEvents };

--- a/src/panels/invokeRenderers.ts
+++ b/src/panels/invokeRenderers.ts
@@ -189,6 +189,10 @@ const invokeRenderers = {
                     }
                     this.renderParameters(thisMethodDetail, methodData.parameters, updateViewState);
                     this.renderIntents(thisMethodDetail, methodData, updateViewState);
+                    const launchDebuggerButton = thisMethodDetail.querySelector(invokeSelectors.LaunchDebuggerButton);
+                    if (launchDebuggerButton) {
+                        htmlHelpers.setOnClickEvent(launchDebuggerButton, invokeEvents.Debug, methodData.name, postMessage);
+                    }
                     const invokeOffChainButton = thisMethodDetail.querySelector(invokeSelectors.InvokeOffChainButton);
                     if (invokeOffChainButton) {
                         htmlHelpers.setOnClickEvent(invokeOffChainButton, invokeEvents.InvokeOffChain, methodData.name, postMessage);

--- a/src/panels/invokeSelectors.ts
+++ b/src/panels/invokeSelectors.ts
@@ -22,6 +22,7 @@ const invokeSelectors = {
     IntentValue: '.intentValue',
     InvokeOnChainButton: '.invokeOnChainButton',
     InvokeOffChainButton: '.invokeOffChainButton',
+    LaunchDebuggerButton: '.launchDebugger',
     InvocationResultPopup: '#invocationResultPopup',
     InvocationResultGasUsed: '#gas-used-value',
     InvocationResultVMState: '#vm-state-value',


### PR DESCRIPTION
This PR adds a "Launch in debugger" button to the contract invocation UI.  When clicked, the neo-debugger will be launched in a way that calls the specified method with the supplied arguments.  It is a requirement that corresponding .avm and .debug.json files are present anywhere in the active workspace (if they cannot be found, the user will see an error).

Fixes https://github.com/neo-project/neo-visual-tracker/issues/31